### PR TITLE
Update openinvoice-server.php

### DIFF
--- a/7.OpenInvoice/httppost/openinvoice-server.php
+++ b/7.OpenInvoice/httppost/openinvoice-server.php
@@ -49,7 +49,8 @@
  *
  */
  
- $orderLines = null;
+ // this needs to be an empty string as Adyen can fail with a 115 response.
+ $orderLines = ''; 
  
  /**
   * Authorisation / Capture
@@ -94,4 +95,5 @@
  	$orderLines .= "openInvoiceDetailResult.lines.0.vatCategory=High";
  }
  
- print $orderLines;
+ // trailing or leading whitespace can cause failure with a 115 error. 
+ print trim($orderLines);


### PR DESCRIPTION
Changes to the file to allow a successful response under circumstances where the output of lines is prefixed with a null or other whitespace. This can cause an error response of 115 Total amount is not the same as the sum of the lines.